### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/lib/gpio_mock.py
+++ b/lib/gpio_mock.py
@@ -9,23 +9,23 @@ OUT = "OUTPUT"
 
 
 def setmode(mode):
-    print("Set mode %s" % mode)
+    print("Set mode {0!s}".format(mode))
 
 
 def setwarnings(mode):
-    print("Set warnings as %s" % mode)
+    print("Set warnings as {0!s}".format(mode))
 
 
 def setup(pin, mode):
-    print("Set pin %s as %s" % (pin, mode))
+    print("Set pin {0!s} as {1!s}".format(pin, mode))
 
 
 def output(pin, value):
-    print("Output %s to pin %s" % (value, pin))
+    print("Output {0!s} to pin {1!s}".format(value, pin))
 
 
 def input(pin):
-    print("Input 0 to pin %s" % s)
+    print("Input 0 to pin {0!s}".format(s))
     return 0
 
 

--- a/lib/gpio_mock.py
+++ b/lib/gpio_mock.py
@@ -9,23 +9,23 @@ OUT = "OUTPUT"
 
 
 def setmode(mode):
-    print("Set mode {0!s}".format(mode))
+    print("Set mode {0}".format(mode))
 
 
 def setwarnings(mode):
-    print("Set warnings as {0!s}".format(mode))
+    print("Set warnings as {0}".format(mode))
 
 
 def setup(pin, mode):
-    print("Set pin {0!s} as {1!s}".format(pin, mode))
+    print("Set pin {0} as {1}".format(pin, mode))
 
 
 def output(pin, value):
-    print("Output {0!s} to pin {1!s}".format(value, pin))
+    print("Output {0} to pin {1}".format(value, pin))
 
 
 def input(pin):
-    print("Input 0 to pin {0!s}".format(s))
+    print("Input 0 to pin {0}".format(s))
     return 0
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:arim215:nhl_goal_light?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:arim215:nhl_goal_light?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
