### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/test/test_source.py
+++ b/test/test_source.py
@@ -61,7 +61,7 @@ def fetch_score2(team):
     game_id = game_id[game_id.find("id") + 4:]
 
     season_id = game_id[:4] + str(int(game_id[:4]) + 1)
-    url = "http://live.nhle.com/GameData/{0!s}/{1!s}/gc/gcbx.jsonp".format(
+    url = "http://live.nhle.com/GameData/{0}/{1}/gc/gcbx.jsonp".format(
         season_id, game_id)
     try:
         score = requests.get(url)

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -61,7 +61,7 @@ def fetch_score2(team):
     game_id = game_id[game_id.find("id") + 4:]
 
     season_id = game_id[:4] + str(int(game_id[:4]) + 1)
-    url = "http://live.nhle.com/GameData/%s/%s/gc/gcbx.jsonp" % (
+    url = "http://live.nhle.com/GameData/{0!s}/{1!s}/gc/gcbx.jsonp".format(
         season_id, game_id)
     try:
         score = requests.get(url)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:arim215:nhl_goal_light?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:arim215:nhl_goal_light?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
