### PR TITLE
Refactor to use current directories instead of hardcoded home path

### DIFF
--- a/lib/light.py
+++ b/lib/light.py
@@ -22,13 +22,13 @@ def setup():
     GPIO.add_event_detect(15, GPIO.RISING, activate_goal_light, 5000)
 
 
-def activate_goal_light(gpio_event_var=0):
+def activate_goal_light(main_dir, gpio_event_var=0):
     """ Function to activate GPIO for goal light and plar random audio clip. """
 
     songrandom = random.randint(1, 3) #Set random numbers depending on number of audio clips available
     GPIO.output(7, GPIO.HIGH) #Turn on light, active low relay, so on is low
     # Prepare commande to play sound (change file name if needed)
-    command_play_song = 'mpg123 -q /home/pi/nhl_goal_light/audio/goal_horn_{SongId}.mp3'.format(SongId=str(songrandom))
+    command_play_song = 'mpg123 -q {directory}/audio/goal_horn_{SongId}.mp3'.format(directory=main_dir,SongId=str(songrandom))
     os.system(command_play_song) # Play sound
     GPIO.output(7, GPIO.LOW) #Turn off light
 

--- a/nhl_goal_light.py
+++ b/nhl_goal_light.py
@@ -46,9 +46,10 @@ def setup_nhl():
     lines = ""
     team = ""
     team_id = ""
-    if os.path.exists('/home/pi/nhl_goal_light/settings.txt'):
+    settings_file = '{0}/settings.txt'.format(main_dir)
+    if os.path.exists(settings_file):
         # get settings from file
-        f = open('/home/pi/nhl_goal_light/settings.txt', 'r')
+        f = open(settings_file, 'r')
         lines = f.readlines()
     
     # find team_id
@@ -80,6 +81,8 @@ def setup_nhl():
 
 
 if __name__ == "__main__":
+
+    main_dir = os.path.dirname(os.path.realpath(__file__))
 
     old_score = 0
     new_score = 0
@@ -120,7 +123,7 @@ if __name__ == "__main__":
                                 # save new score
                                 print("GOAL!")
                                 # activate_goal_light()
-                                light.activate_goal_light()
+                                light.activate_goal_light(main_dir = main_dir)
                             old_score = new_score
                             
 


### PR DESCRIPTION
I structure my development under different directories so when I initially pulled nhl_goal_light, it wouldn't play sounds or use the settings file. A little digging showed that this was because the code was always looking for the audio and settings files in the home directory.

I refactored the project to find the project's main directory on startup and then use that to locate the audio/settings files. This should make the project more robust and allow it to be placed anywhere.